### PR TITLE
Nanopub URI check was affected by carriage returns as it splits on line feed

### DIFF
--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -24,7 +24,7 @@ jest.mock('@octokit/rest', () => {
             },
             {
               number: '22',
-              body: 'http://purl.org/np/RAS\n# Review\n\n| Item     | Detail     |',
+              body: 'http://purl.org/np/RAS\r\n# Review\r\n\r\n| Item     | Detail     |',
               title: 'Test WDCC',
               state: 'open'
             },

--- a/src/issue.js
+++ b/src/issue.js
@@ -80,10 +80,11 @@ async function getActionIssuesPage(pageSize, issuePage) {
   })
 
   // map necessary fields & return
+  // #48 Remove any carriage returns from the first line
   const records = response.data.map(x => ({
     number: x.number,
     body: x.body,
-    firstLine: String(x.body).split('\n')[0],
+    firstLine: String(x.body).split('\n')[0].replace(/\r/g, ''),
     title: x.title,
     state: x.state
   }))


### PR DESCRIPTION
Resolves 48